### PR TITLE
[feature]: Adds `sendTransactionalEmails` method to use the `batch/emails` endpoint for transactional emails

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
     "node": true
   },
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "arrow-parens": ["error", "as-needed"]
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "semi": true,
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "arrowParens": "avoid"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5",
+  "printWidth": 80,
   "arrowParens": "avoid"
 }

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ const bento = new Analytics({
 bento.V1.addSubscriber({
   email: 'test@bentonow.com',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 
 bento.V1.updateFields({
   email: 'test@bentonow.com',
@@ -93,8 +93,8 @@ bento.V1.updateFields({
     lastName: 'User',
   },
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 
 bento.V1.trackPurchase({
   email: 'test@bentonow.com',
@@ -135,8 +135,8 @@ bento.V1.tagSubscriber({
   email: 'test@bentonow.com',
   tagName: 'Test Tag',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -159,8 +159,8 @@ Reference Types: [AddSubscriberParameters\<S\>](#addsubscriberparameterss)
 bento.V1.addSubscriber({
   email: 'test@bentonow.com',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 
 bento.V1.addSubscriber({
   date: new Date('2021-08-20T01:32:57.530Z'),
@@ -170,8 +170,8 @@ bento.V1.addSubscriber({
     lastName: 'Subscriber',
   },
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -192,8 +192,8 @@ Reference Types: [RemoveSubscriberParameters](#RemoveSubscriberParameters)
 bento.V1.removeSubscriber({
   email: 'test@bentonow.com',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -217,8 +217,8 @@ bento.V1.updateFields({
     firstName: 'Test',
   },
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -248,8 +248,8 @@ bento.V1.trackPurchase({
     },
   },
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -278,8 +278,8 @@ bento.V1.track({
     fromCustomEvent: true,
   },
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ## Batch
@@ -314,8 +314,8 @@ bento.V1.Batch.importSubscribers({
     },
   ],
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -395,8 +395,8 @@ bento.V1.Batch.importEmails({
     },
   ],
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ## Commands
@@ -416,8 +416,8 @@ bento.V1.Commands.addTag({
   email: 'test@bentonow.com',
   tagName: 'Test Tag',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -433,8 +433,8 @@ bento.V1.Commands.removeTag({
   email: 'test@bentonow.com',
   tagName: 'Test Tag',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -457,8 +457,8 @@ bento.V1.Commands.addField({
     value: 'testValue',
   },
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -474,8 +474,8 @@ bento.V1.Commands.removeField({
   email: 'test@bentonow.com',
   fieldName: 'testField',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -494,8 +494,8 @@ Reference Types: [SubscribeParameters](#SubscribeParameters), [Subscriber\<S\>](
 bento.V1.Commands.subscribe({
   email: 'test@bentonow.com',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -512,8 +512,8 @@ Reference Types: [UnsubscribeParameters](#UnsubscribeParameters), [Subscriber\<S
 bento.V1.Commands.unsubscribe({
   email: 'test@bentonow.com',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -529,8 +529,8 @@ bento.V1.Commands.changeEmail({
   oldEmail: 'test@bentonow.com',
   newEmail: 'new@bentonow.com',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ## Experimental
@@ -549,8 +549,8 @@ Reference Types: [ValidateEmailParameters](#ValidateEmailParameters)
 bento.V1.Experimental.validateEmail({
   email: 'test@bentonow.com',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -569,8 +569,8 @@ Reference Types: [GuessGenderParameters](#GuessGenderParameters), [GuessGenderRe
 bento.V1.Experimental.guessGender({
   name: 'Jesse',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -587,8 +587,8 @@ Reference Types: [GeolocateParameters](#GeolocateParameters), [LocationData](#Lo
 bento.V1.Experimental.geolocate({
   ip: '127.0.0.1',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -605,8 +605,8 @@ Reference Types: [BlacklistParameters](#BlacklistParameters), [BlacklistResponse
 bento.V1.Experimental.checkBlacklist({
   domain: 'bentonow.com',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ## Fields
@@ -621,8 +621,8 @@ Reference Types: [Field](#Field)
 bento.V1.Experimental.validateEmail({
   email: 'test@bentonow.com',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -644,8 +644,8 @@ Reference Types: [CreateFieldParameters](#CreateFieldParameters), [Field](#Field
 bento.V1.Fields.createField({
   key: 'testKey',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ## Forms
@@ -658,8 +658,8 @@ Reference Types: [FormResponse](#FormResponse)
 
 ```ts
 bento.V1.Forms.getResponses('test-formid-1234')
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ## Subscribers
@@ -674,14 +674,14 @@ Reference Types: [GetSubscribersParameters](#GetSubscribersParameters), [Subscri
 bento.V1.Subscribers.getSubscribers({
   uuid: '1234',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 
 bento.V1.Subscribers.getSubscribers({
   email: 'test@bentonow.com',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -696,8 +696,8 @@ Reference Types: [CreateSubscriberParameters](#CreateSubscriberParameters), [Sub
 bento.V1.Subscribers.createSubscriber({
   email: 'test@bentonow.com',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ## Tags
@@ -710,8 +710,8 @@ Reference Types: [Tag](#Tag)
 
 ```ts
 bento.V1.Tags.getTags()
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ---
@@ -726,8 +726,8 @@ Reference Types: [Tag](#Tag)
 bento.V1.Tags.createTag({
   name: 'test tag',
 })
-  .then((result) => console.log(result))
-  .catch((error) => console.error(error));
+  .then(result => console.log(result))
+  .catch(error => console.error(error));
 ```
 
 ## Types Reference

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ const bento = new Analytics({
 bento.V1.addSubscriber({
   email: 'test@bentonow.com',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 
 bento.V1.updateFields({
   email: 'test@bentonow.com',
@@ -93,8 +93,8 @@ bento.V1.updateFields({
     lastName: 'User',
   },
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 
 bento.V1.trackPurchase({
   email: 'test@bentonow.com',
@@ -135,8 +135,8 @@ bento.V1.tagSubscriber({
   email: 'test@bentonow.com',
   tagName: 'Test Tag',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -159,8 +159,8 @@ Reference Types: [AddSubscriberParameters\<S\>](#addsubscriberparameterss)
 bento.V1.addSubscriber({
   email: 'test@bentonow.com',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 
 bento.V1.addSubscriber({
   date: new Date('2021-08-20T01:32:57.530Z'),
@@ -170,8 +170,8 @@ bento.V1.addSubscriber({
     lastName: 'Subscriber',
   },
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -192,8 +192,8 @@ Reference Types: [RemoveSubscriberParameters](#RemoveSubscriberParameters)
 bento.V1.removeSubscriber({
   email: 'test@bentonow.com',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -217,8 +217,8 @@ bento.V1.updateFields({
     firstName: 'Test',
   },
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -248,8 +248,8 @@ bento.V1.trackPurchase({
     },
   },
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -271,15 +271,15 @@ bento.V1.track({
   email: 'test@bentonow.com',
   type: '$custom.event',
   fields: {
-        firstName: 'Custom Name',
-        lastName: 'Custom Name',
+    firstName: 'Custom Name',
+    lastName: 'Custom Name',
   },
   details: {
     fromCustomEvent: true,
   },
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ## Batch
@@ -306,7 +306,7 @@ bento.V1.Batch.importSubscribers({
     {
       email: 'test2@bentonow.com',
       some_custom_variable: 'tester-123',
-      primary_user: true
+      primary_user: true,
     },
     {
       email: 'test3@bentonow.com',
@@ -314,8 +314,8 @@ bento.V1.Batch.importSubscribers({
     },
   ],
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -366,6 +366,39 @@ bento.V1.Batch.importEvents({
   .catch(error => console.error(error));
 ```
 
+---
+
+### `Batch.importEmails(parameters: BatchImportEmailsParameter<S, E>): Promise<number>`
+
+Creates a batch job to import transactional emails into the system. You can pass in between 1 and 100 emails to import. Each email must have a `to` address, a `from` address, a `subject`, an `html_body` and `transactional: true`.
+
+In addition you can add a `personalization` object to proviede liquid tsags that will be injected into the email.
+
+Requests are instant and queued into a priority queue. Most requests will be processed within 30 seconds. We currently limit this endpoint to 60 emails per minute.
+
+Returns the number of emails that were imported.
+
+Reference Types: [BatchImportEventsParameter<S, E>](#batchimporteventsparameterse)
+
+```ts
+bento.V1.Batch.importEmails({
+  emails: [
+    {
+      to: 'test@bentonow.com', // required — if no user with this email exists in your account they will be created.
+      from: 'jesse@bentonow.com', // required — must be an email author in your account.
+      subject: 'Reset Password', // required
+      html_body: '<p>Here is a link to reset your password ... {{ link }}</p>', // required - can also use text_body if you want to use our plain text theme.
+      transactional: true, // IMPORTANT — this bypasses the subscription status of a user. Abuse will lead to account shutdown.
+      personalizations: {
+        link: 'https://example.com/test',
+      }, // optional — provide your own Liquid tags to be injected into the email.
+    },
+  ],
+})
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
+```
+
 ## Commands
 
 ### `Commands.addTag(parameters: AddTagParameters): Promise<Subscriber<S> | null>`
@@ -383,8 +416,8 @@ bento.V1.Commands.addTag({
   email: 'test@bentonow.com',
   tagName: 'Test Tag',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -400,8 +433,8 @@ bento.V1.Commands.removeTag({
   email: 'test@bentonow.com',
   tagName: 'Test Tag',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -424,8 +457,8 @@ bento.V1.Commands.addField({
     value: 'testValue',
   },
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -441,8 +474,8 @@ bento.V1.Commands.removeField({
   email: 'test@bentonow.com',
   fieldName: 'testField',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -461,8 +494,8 @@ Reference Types: [SubscribeParameters](#SubscribeParameters), [Subscriber\<S\>](
 bento.V1.Commands.subscribe({
   email: 'test@bentonow.com',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -479,8 +512,8 @@ Reference Types: [UnsubscribeParameters](#UnsubscribeParameters), [Subscriber\<S
 bento.V1.Commands.unsubscribe({
   email: 'test@bentonow.com',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -496,8 +529,8 @@ bento.V1.Commands.changeEmail({
   oldEmail: 'test@bentonow.com',
   newEmail: 'new@bentonow.com',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ## Experimental
@@ -516,8 +549,8 @@ Reference Types: [ValidateEmailParameters](#ValidateEmailParameters)
 bento.V1.Experimental.validateEmail({
   email: 'test@bentonow.com',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -536,8 +569,8 @@ Reference Types: [GuessGenderParameters](#GuessGenderParameters), [GuessGenderRe
 bento.V1.Experimental.guessGender({
   name: 'Jesse',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -554,8 +587,8 @@ Reference Types: [GeolocateParameters](#GeolocateParameters), [LocationData](#Lo
 bento.V1.Experimental.geolocate({
   ip: '127.0.0.1',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -572,8 +605,8 @@ Reference Types: [BlacklistParameters](#BlacklistParameters), [BlacklistResponse
 bento.V1.Experimental.checkBlacklist({
   domain: 'bentonow.com',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ## Fields
@@ -588,8 +621,8 @@ Reference Types: [Field](#Field)
 bento.V1.Experimental.validateEmail({
   email: 'test@bentonow.com',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -611,8 +644,8 @@ Reference Types: [CreateFieldParameters](#CreateFieldParameters), [Field](#Field
 bento.V1.Fields.createField({
   key: 'testKey',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ## Forms
@@ -625,8 +658,8 @@ Reference Types: [FormResponse](#FormResponse)
 
 ```ts
 bento.V1.Forms.getResponses('test-formid-1234')
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ## Subscribers
@@ -641,14 +674,14 @@ Reference Types: [GetSubscribersParameters](#GetSubscribersParameters), [Subscri
 bento.V1.Subscribers.getSubscribers({
   uuid: '1234',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 
 bento.V1.Subscribers.getSubscribers({
   email: 'test@bentonow.com',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -663,8 +696,8 @@ Reference Types: [CreateSubscriberParameters](#CreateSubscriberParameters), [Sub
 bento.V1.Subscribers.createSubscriber({
   email: 'test@bentonow.com',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ## Tags
@@ -677,8 +710,8 @@ Reference Types: [Tag](#Tag)
 
 ```ts
 bento.V1.Tags.getTags()
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ---
@@ -693,8 +726,8 @@ Reference Types: [Tag](#Tag)
 bento.V1.Tags.createTag({
   name: 'test tag',
 })
-  .then(result => console.log(result))
-  .catch(error => console.error(error));
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
 ```
 
 ## Types Reference

--- a/README.md
+++ b/README.md
@@ -368,20 +368,18 @@ bento.V1.Batch.importEvents({
 
 ---
 
-### `Batch.importEmails(parameters: BatchImportEmailsParameter<S, E>): Promise<number>`
+### `Batch.sendTransactionalEmails(parameters: BatchsendTransactionalEmailsParameter<S, E>): Promise<number>`
 
-Creates a batch job to import transactional emails into the system. You can pass in between 1 and 100 emails to import. Each email must have a `to` address, a `from` address, a `subject`, an `html_body` and `transactional: true`.
+Creates a batch job to send transactional emails from Bento's infrastructure. You can pass in between 1 and 100 emails to send. Each email must have a `to` address, a `from` address, a `subject`, an `html_body` and `transactional: true`.
 
-In addition you can add a `personalization` object to proviede liquid tsags that will be injected into the email.
+In addition you can add a `personalizations` object to provide liquid tags that will be injected into the email.
 
 Requests are instant and queued into a priority queue. Most requests will be processed within 30 seconds. We currently limit this endpoint to 60 emails per minute.
 
 Returns the number of emails that were imported.
 
-Reference Types: [BatchImportEventsParameter<S, E>](#batchimporteventsparameterse)
-
 ```ts
-bento.V1.Batch.importEmails({
+bento.V1.Batch.sendTransactionalEmails({
   emails: [
     {
       to: 'test@bentonow.com', // required — if no user with this email exists in your account they will be created.

--- a/package.json
+++ b/package.json
@@ -25,12 +25,6 @@
       "pre-commit": "tsdx lint"
     }
   },
-  "prettier": {
-    "printWidth": 80,
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "es5"
-  },
   "name": "@bentonow/bento-node-sdk",
   "author": "Backpack Internet",
   "module": "dist/bento-node-sdk.esm.js",

--- a/src/sdk/batch/errors.ts
+++ b/src/sdk/batch/errors.ts
@@ -25,3 +25,17 @@ export class TooManyEventsError extends Error {
     this.name = 'TooManyEventsError';
   }
 }
+
+export class TooFewEmailsError extends Error {
+  constructor(message = 'Too few emails') {
+    super(message);
+    this.name = 'TooFewEmailsError';
+  }
+}
+
+export class TooManyEmailsError extends Error {
+  constructor(message = 'Too many emails') {
+    super(message);
+    this.name = 'TooManyEmailsError';
+  }
+}

--- a/src/sdk/batch/index.ts
+++ b/src/sdk/batch/index.ts
@@ -1,7 +1,9 @@
 import type { BentoClient } from '../client';
 import {
+  TooFewEmailsError,
   TooFewEventsError,
   TooFewSubscribersError,
+  TooManyEmailsError,
   TooManyEventsError,
   TooManySubscribersError,
 } from './errors';
@@ -115,11 +117,11 @@ export class BentoBatch<S, E extends string> {
     parameters: BatchImportEmailsParameter
   ): Promise<number> {
     if (parameters.emails.length === 0) {
-      throw new TooFewEventsError(`You must send between 1 and 100 emails.`);
+      throw new TooFewEmailsError(`You must send between 1 and 100 emails.`);
     }
 
     if (parameters.emails.length > this._maxEmailBatchSize) {
-      throw new TooManyEventsError(`You must send between 1 and 100 emails.`);
+      throw new TooManyEmailsError(`You must send between 1 and 100 emails.`);
     }
 
     const result = await this._client.post<BatchImportEmailsResponse>(

--- a/src/sdk/batch/index.ts
+++ b/src/sdk/batch/index.ts
@@ -6,6 +6,8 @@ import {
   TooManySubscribersError,
 } from './errors';
 import type {
+  BatchImportEmailsParameter,
+  BatchImportEmailsResponse,
   BatchImportEventsParameter,
   BatchImportEventsResponse,
   BatchImportSubscribersParameter,
@@ -13,6 +15,7 @@ import type {
 } from './types';
 
 export class BentoBatch<S, E extends string> {
+  private readonly _maxEmailBatchSize = 100;
   private readonly _maxBatchSize = 1000;
   private readonly _url = '/batch';
 
@@ -87,6 +90,42 @@ export class BentoBatch<S, E extends string> {
       `${this._url}/events`,
       {
         events: parameters.events,
+      }
+    );
+
+    return result.results;
+  }
+
+  /**
+   * Creates a batch job to import emails into the system. You can pass in
+   * between 1 and 100 emails to import.
+   * Creates a batch job to import transactional emails into the system.
+   * You can pass in between 1 and 100 emails to import.
+   * Each email must have a `to` address, a `from` address, a `subject`, an `html_body`
+   * and `transactional: true`.
+   * In addition you can add a `personalization` object to provide
+   * liquid tsags that will be injected into the email.
+   *
+   * Returns the number of events that were imported.
+   *
+   * @param parameters
+   * @returns Promise\<number\>
+   */
+  public async importEmails(
+    parameters: BatchImportEmailsParameter
+  ): Promise<number> {
+    if (parameters.emails.length === 0) {
+      throw new TooFewEventsError(`You must send between 1 and 100 emails.`);
+    }
+
+    if (parameters.emails.length > this._maxEmailBatchSize) {
+      throw new TooManyEventsError(`You must send between 1 and 100 emails.`);
+    }
+
+    const result = await this._client.post<BatchImportEmailsResponse>(
+      `${this._url}/emails`,
+      {
+        emails: parameters.emails,
       }
     );
 

--- a/src/sdk/batch/index.ts
+++ b/src/sdk/batch/index.ts
@@ -8,8 +8,8 @@ import {
   TooManySubscribersError,
 } from './errors';
 import type {
-  BatchImportEmailsParameter,
-  BatchImportEmailsResponse,
+  BatchSendTransactionalEmailsParameter,
+  BatchsendTransactionalEmailsResponse,
   BatchImportEventsParameter,
   BatchImportEventsResponse,
   BatchImportSubscribersParameter,
@@ -99,13 +99,12 @@ export class BentoBatch<S, E extends string> {
   }
 
   /**
-   * Creates a batch job to import emails into the system. You can pass in
-   * between 1 and 100 emails to import.
-   * Creates a batch job to import transactional emails into the system.
-   * You can pass in between 1 and 100 emails to import.
+   * Creates a batch job to send transactional emails from Bento's infrastructure. You can pass in
+   * between 1 and 100 emails to send.
+   *
    * Each email must have a `to` address, a `from` address, a `subject`, an `html_body`
    * and `transactional: true`.
-   * In addition you can add a `personalization` object to provide
+   * In addition you can add a `personalizations` object to provide
    * liquid tsags that will be injected into the email.
    *
    * Returns the number of events that were imported.
@@ -113,8 +112,8 @@ export class BentoBatch<S, E extends string> {
    * @param parameters
    * @returns Promise\<number\>
    */
-  public async importEmails(
-    parameters: BatchImportEmailsParameter
+  public async sendTransactionalEmails(
+    parameters: BatchSendTransactionalEmailsParameter
   ): Promise<number> {
     if (parameters.emails.length === 0) {
       throw new TooFewEmailsError(`You must send between 1 and 100 emails.`);
@@ -124,12 +123,13 @@ export class BentoBatch<S, E extends string> {
       throw new TooManyEmailsError(`You must send between 1 and 100 emails.`);
     }
 
-    const result = await this._client.post<BatchImportEmailsResponse>(
-      `${this._url}/emails`,
-      {
-        emails: parameters.emails,
-      }
-    );
+    const result =
+      await this._client.post<BatchsendTransactionalEmailsResponse>(
+        `${this._url}/emails`,
+        {
+          emails: parameters.emails,
+        }
+      );
 
     return result.results;
   }

--- a/src/sdk/batch/types.ts
+++ b/src/sdk/batch/types.ts
@@ -13,6 +13,19 @@ export type BatchImportEventsParameter<S, E extends string> = {
   events: BentoEvent<S, E>[];
 };
 
+export type BatchImportEmail = {
+  to: string;
+  from: string;
+  subject: string;
+  html_body: string;
+  transactional: boolean;
+  personalization?: { [key: string]: string };
+};
+
+export type BatchImportEmailsParameter = {
+  emails: BatchImportEmail[];
+};
+
 /**
  * Batch Method Response Types
  */
@@ -21,5 +34,9 @@ export type BatchImportSubscribersResponse = {
 };
 
 export type BatchImportEventsResponse = {
+  results: number;
+};
+
+export type BatchImportEmailsResponse = {
   results: number;
 };

--- a/src/sdk/batch/types.ts
+++ b/src/sdk/batch/types.ts
@@ -19,7 +19,7 @@ export type BatchImportEmail = {
   subject: string;
   html_body: string;
   transactional: boolean;
-  personalization?: { [key: string]: string };
+  personalizations?: { [key: string]: string };
 };
 
 export type BatchImportEmailsParameter = {

--- a/src/sdk/batch/types.ts
+++ b/src/sdk/batch/types.ts
@@ -19,7 +19,9 @@ export type BatchImportEmail = {
   subject: string;
   html_body: string;
   transactional: boolean;
-  personalizations?: { [key: string]: string };
+  personalizations?: {
+    [key: string]: string | number | boolean;
+  };
 };
 
 export type BatchImportEmailsParameter = {

--- a/src/sdk/batch/types.ts
+++ b/src/sdk/batch/types.ts
@@ -13,7 +13,7 @@ export type BatchImportEventsParameter<S, E extends string> = {
   events: BentoEvent<S, E>[];
 };
 
-export type BatchImportEmail = {
+export type TransactionalEmail = {
   to: string;
   from: string;
   subject: string;
@@ -24,8 +24,8 @@ export type BatchImportEmail = {
   };
 };
 
-export type BatchImportEmailsParameter = {
-  emails: BatchImportEmail[];
+export type BatchSendTransactionalEmailsParameter = {
+  emails: TransactionalEmail[];
 };
 
 /**
@@ -39,6 +39,6 @@ export type BatchImportEventsResponse = {
   results: number;
 };
 
-export type BatchImportEmailsResponse = {
+export type BatchsendTransactionalEmailsResponse = {
   results: number;
 };

--- a/test/batch.spec.ts
+++ b/test/batch.spec.ts
@@ -5,6 +5,8 @@ import {
   TooFewSubscribersError,
   TooManyEventsError,
   TooManySubscribersError,
+  TooManyEmailsError,
+  TooFewEmailsError,
 } from '../src/sdk/batch/errors';
 
 describe('[V1] Batch Import Subscribers [/batch/subscribers]', () => {
@@ -132,5 +134,78 @@ describe('[V1] Batch Import Events [/batch/events]', () => {
         events: new Array(1001),
       })
     ).rejects.toThrow(TooManyEventsError);
+  });
+});
+
+describe('[V1] Batch Import Emails [/batch/emails]', () => {
+  it('Can import between 1 and 100 emails', async () => {
+    const bento = new Analytics({
+      authentication: {
+        secretKey: 'test',
+        publishableKey: 'test',
+      },
+      siteUuid: 'test',
+    });
+
+    await expect(
+      bento.V1.Batch.importEmails({
+        emails: [
+          {
+            to: 'test_one@bentonow.com',
+            from: 'jesse@bentonow.com',
+            subject: 'Reset Password',
+            html_body:
+              '<p>Here is a link to reset your password ... {{ link }}</p>',
+            transactional: true,
+            personalizations: {
+              link: 'https://example.com/test',
+            },
+          },
+          {
+            to: 'test_two@bentonow.com',
+            from: 'jesse@bentonow.com',
+            subject: 'Reset Password',
+            html_body:
+              '<p>Here is a link to reset your password ... {{ link }}</p>',
+            transactional: true,
+            personalizations: {
+              link: 'https://example.com/test',
+            },
+          },
+        ],
+      })
+    ).resolves.toBe(2);
+  });
+
+  it('Errors out when importing 0 events.', async () => {
+    const bento = new Analytics({
+      authentication: {
+        secretKey: 'test',
+        publishableKey: 'test',
+      },
+      siteUuid: 'test',
+    });
+
+    await expect(
+      bento.V1.Batch.importEmails({
+        emails: [],
+      })
+    ).rejects.toThrow(TooFewEmailsError);
+  });
+
+  it('Errors out when importing 101 events.', async () => {
+    const bento = new Analytics({
+      authentication: {
+        secretKey: 'test',
+        publishableKey: 'test',
+      },
+      siteUuid: 'test',
+    });
+
+    await expect(
+      bento.V1.Batch.importEmails({
+        emails: new Array(101),
+      })
+    ).rejects.toThrow(TooManyEmailsError);
   });
 });

--- a/test/batch.spec.ts
+++ b/test/batch.spec.ts
@@ -148,7 +148,7 @@ describe('[V1] Batch Import Emails [/batch/emails]', () => {
     });
 
     await expect(
-      bento.V1.Batch.importEmails({
+      bento.V1.Batch.sendTransactionalEmails({
         emails: [
           {
             to: 'test_one@bentonow.com',
@@ -177,7 +177,7 @@ describe('[V1] Batch Import Emails [/batch/emails]', () => {
     ).resolves.toBe(2);
   });
 
-  it('Errors out when importing 0 events.', async () => {
+  it('Errors out when importing 0 emails.', async () => {
     const bento = new Analytics({
       authentication: {
         secretKey: 'test',
@@ -187,13 +187,13 @@ describe('[V1] Batch Import Emails [/batch/emails]', () => {
     });
 
     await expect(
-      bento.V1.Batch.importEmails({
+      bento.V1.Batch.sendTransactionalEmails({
         emails: [],
       })
     ).rejects.toThrow(TooFewEmailsError);
   });
 
-  it('Errors out when importing 101 events.', async () => {
+  it('Errors out when importing 101 emails.', async () => {
     const bento = new Analytics({
       authentication: {
         secretKey: 'test',
@@ -203,7 +203,7 @@ describe('[V1] Batch Import Emails [/batch/emails]', () => {
     });
 
     await expect(
-      bento.V1.Batch.importEmails({
+      bento.V1.Batch.sendTransactionalEmails({
         emails: new Array(101),
       })
     ).rejects.toThrow(TooManyEmailsError);

--- a/test/mocks/handlers/batch.ts
+++ b/test/mocks/handlers/batch.ts
@@ -38,4 +38,21 @@ export const handlers = [
       );
     }
   ),
+  rest.post(
+    'https://app.bentonow.com/api/v1/batch/emails',
+    async (req, res: ResponseComposition<any>, ctx: RestContext) => {
+      if (req.headers.get('Authorization') !== 'Basic dGVzdDp0ZXN0') {
+        return basicAuthError(res, ctx);
+      }
+
+      const body = req.body as { emails: unknown[] };
+
+      return res(
+        ctx.status(201),
+        ctx.json({
+          results: body.emails.length,
+        })
+      );
+    }
+  ),
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,6 @@
     // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true,
     // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
-    "noEmit": true,
+    "noEmit": true
   }
 }


### PR DESCRIPTION
## Scope

Adding support for the batch email import (AKA transactional) Bento API. 

View the docs for the API endpoint here: https://docs.bentonow.com/batch-api/emails

I've followed convention and called this `importEmails` to match the `importSubscribers` and `importEvents` methods, but on reflection... I don't see a reason why it couldn't be called `sendTransactionalEmails` - a clearer name, `importEmails` kind of sounds like `importSubcribers` but only their email addresses? 

UPDATE: I went ahead and renamed the method name to `sendTransactionalEmails`

One to get some feedback on.

## Implementation

The bulk of the work is handled by the rest of the API. I'd say the only really "email-centric" code is the type added to `sdk/batch/types` - along with the new method `sendTransactionEmails` which follows the same conventions as the other batch import methods.

```ts
export type TransactionalEmail = {
  to: string;
  from: string;
  subject: string;
  html_body: string;
  transactional: boolean;
  personalizations?: {
    [key: string]: string | number | boolean;
  };
};
```

This matches the API spec and the requirements of the endpoint

## How to Test

A coupe of tests have been added to the `batch` suite of tests, checking that we throw an error if 0 emails, or more than 100 are passed into the method.

### Install this branch and send a test transactional email _for real!_

```sh
npm install git://github.com/jonsherrard/bento-node-sdk#feature/batch-email-api-method --save 
```

Run this script:

```js
// Make sure you use `type: module` in your package.json

// Update publishableKey, secretKey, siteUiid and `from` with an "Author" in your Bento account

import { Analytics } from '@bentonow/bento-node-sdk';

const bento = new Analytics({
  authentication: {
    publishableKey: 'foo',
    secretKey: 'bar',
  },
  logErrors: true, // Set to true to see the HTTP errors logged
  siteUuid: 'baz',
});

bento.V1.Batch.sendTransactionalEmails({
  emails: [
    {
      to: 'test@bentonow.com', // required — if no user with this email exists in your account they will be created.
      from: 'jesse@bentonow.com', // required — NB: must be an email author in your account.
      subject: 'This is a test from the Node SDK', // required
      html_body: '<p>Here is a link to reset your password ... {{ link }}</p>', // required - can also use text_body if you want to use our plain text theme.
      transactional: true, // IMPORTANT — this bypasses the subscription status of a user. Abuse will lead to account shutdown.
      personalizations: {
        link: 'https://example.com/test',
      }, // optional — provide your own Liquid tags to be injected into the email.
    },
  ],
})
  .then((result) => console.log(result))
  .catch((error) => console.error(error));
```

<img width="584" alt="image" src="https://user-images.githubusercontent.com/631670/207379224-57c7acee-fe23-485b-9ffb-14e02ab6d328.png">

## Note on Prettier

Earlier versions of this PR had a bunch of formatting changes in there. Prettier was configured through `.prettierrc` AND `package.json`, and the package.json config was taking precedence, very confusing. 

I've updated the repo to use `.prettierrc` only, and everything seems good 👍 

