### PR TITLE
fix: add explicit import to support CF workers

### DIFF
--- a/src/sdk/client/index.ts
+++ b/src/sdk/client/index.ts
@@ -1,4 +1,5 @@
 import fetch from 'cross-fetch';
+import { Buffer } from 'node:buffer';
 import type { AnalyticsOptions, AuthenticationOptions } from '../interfaces';
 import { NotAuthorizedError, RateLimitedError } from './errors';
 


### PR DESCRIPTION
This PR allow to fix the bug I have in production env where I deploy on Cloudflare workers, as documented here:
https://developers.cloudflare.com/workers/runtime-apis/nodejs/buffer/
It only requires using the import explicitly instead of implicit, as Node.js env allows it.