### PR TITLE
Directly manage package version 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,8 @@ jobs:
 
       - name: Update package version
         run: |
-          npm version $VERSION --no-git-tag-version
+          # Direct modification of package.json
+          jq ".version = \"$VERSION\"" package.json > temp.json && mv temp.json package.json
 
       - name: Generate Release Notes
         id: release_notes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentonow/bento-node-sdk",
-  "version": "1.0.0",
+  "version": "1.0.7",
   "description": "🍱 Bento Node.JS SDK and tracking library",
   "author": "Backpack Internet",
   "license": "MIT",


### PR DESCRIPTION
fix: directly manage the package.json version in the release workflow instead of using a npm command that can fail. 